### PR TITLE
Change all references to terminator->blessings

### DIFF
--- a/noseprogressive/result.py
+++ b/noseprogressive/result.py
@@ -1,6 +1,6 @@
 from nose.result import TextTestResult
 from nose.util import isclass
-from terminator import Terminal
+from blessings import Terminal
 
 from noseprogressive.bar import ProgressBar
 from noseprogressive.tracebacks import format_traceback, extract_relevant_tb

--- a/noseprogressive/tracebacks.py
+++ b/noseprogressive/tracebacks.py
@@ -4,7 +4,7 @@ import os
 from traceback import extract_tb, format_exception_only
 
 from nose.util import src
-from terminator import Terminal
+from blessings import Terminal
 
 from noseprogressive.utils import human_path
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email='erikrose@grinchcentral.com',
     license='GPL',
     packages=find_packages(exclude=['ez_setup']),
-    install_requires=['Nose', 'terminator'],
+    install_requires=['Nose', 'blessings'],
     url='',
     include_package_data=True,
     entry_points="""


### PR DESCRIPTION
Just stumbled upon this today, and I'm assuming you have since renamed terminator to "blessings", so here's a fix.
