### PR TITLE
UnicodeDecodeError issue

### DIFF
--- a/noseprogressive/result.py
+++ b/noseprogressive/result.py
@@ -79,7 +79,7 @@ class ProgressiveResult(TextTestResult):
                     self._term,
                     self._options.function_color,
                     self._options.dim_color,
-                    self._options.editor)))
+                    self._options.editor)).encode('utf-8'))
 
     def _printHeadline(self, kind, test, is_failure=True):
         """Output a 1-line error summary to the stream if appropriate.

--- a/noseprogressive/tracebacks.py
+++ b/noseprogressive/tracebacks.py
@@ -57,7 +57,7 @@ def format_traceback(extracted_tb,
         # Stack frames:
         for i, (file, line, function, text) in enumerate(extracted_tb):
             yield (format_shortcut(editor, file, line, function) +
-                   ('    %s\n' % (text or '')))
+                   ('    %s\n' % (text or '')).decode('utf-8'))
 
     # Exception:
     if exc_type is SyntaxError:


### PR DESCRIPTION
See the following example:

``` python
# coding: utf-8

import unittest


class TestUnicode(unittest.TestCase):
    def test_unicode(self):
        self.assertEquals(u'あ', u'い')
```

Output the `nosetests` and `nosetests --with-progressive`:

```
% nosetests test.py
F
======================================================================
FAIL: test_unicode (test.TestUnicode)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/naoina/work/src/nose-progressive/test.py", line 8, in test_unicode
    self.assertEquals(u'あ', u'い')
AssertionError: u'\u3042' != u'\u3044'

----------------------------------------------------------------------
Ran 1 test in 0.002s

FAILED (failures=1)
```

```
% nosetests --with-progressive test.py 

FAIL: test:TestUnicode.test_unicode

ERROR: test:TestUnicode.test_unicode
  /usr/bin/vim +133 b/lib/python2.6/site-packages/nose-1.1.2-py2.6.egg/nose/case.py  # run
    self.runTest(result)
  /usr/bin/vim +151 b/lib/python2.6/site-packages/nose-1.1.2-py2.6.egg/nose/case.py  # runTest
    test(result)
  /usr/bin/vim +300 /usr/lib/python2.6/unittest.py  # __call__
    return self.run(*args, **kwds)
  /usr/bin/vim +282 /usr/lib/python2.6/unittest.py  # run
    result.addFailure(self, self._exc_info())
  /usr/bin/vim +150 b/lib/python2.6/site-packages/nose-1.1.2-py2.6.egg/nose/proxy.py  # addFailure
    self.result.addFailure(self.test, self._prepareErr(err))
  /usr/bin/vim +156 noseprogressive/result.py  # addFailure
    self._printTraceback(test, err)
  /usr/bin/vim +82  noseprogressive/result.py  # _printTraceback
    self._options.editor)))
  /usr/bin/vim +60  noseprogressive/tracebacks.py  # format_traceback
    ('    %s\n' % (text or '')))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe3 in position 24: ordinal not in range(128)

1 test, 1 failure, 1 error in 0.0s
```
