### PR TITLE
better output: show test args when using generators

### DIFF
--- a/noseprogressive/utils.py
+++ b/noseprogressive/utils.py
@@ -26,7 +26,10 @@ def nose_selector(test):
 
         if module:
             if rest:
-                return '%s:%s%s' % (module, rest, test.test.arg or '')
+                try:
+                    return '%s:%s%s' % (module, rest, test.test.arg or '')
+                except AttributeError:
+                    return '%s:%s' % (module, rest)
             else:
                 return module
     return 'Unknown test'


### PR DESCRIPTION
`_printHeadline` will now output something like:

```
FAIL: siacg62.tests.test_basket:test_Basket.test_associate_ue_matrice('admin',)
```
