### PR TITLE
Allow other nose plugins to process test loader

### DIFF
--- a/noseprogressive/plugin.py
+++ b/noseprogressive/plugin.py
@@ -178,7 +178,6 @@ class ProgressivePlugin(Plugin):
         if hasattr(loader, 'loadTestsFromNames'):
             loader.loadTestsFromNames = partial(capture_suite,
                                                 loader.loadTestsFromNames)
-        return loader
 
     def prepareTestRunner(self, runner):
         """Replace TextTestRunner with something that prints fewer dots."""


### PR DESCRIPTION
Currently, running tests with `--with-progressive` option does not allow other nose plugins to process the test loader. This doesn't seem good.

`--with-progressive` option is really cool and I wanna use it my custom nose plugins.
