### PR TITLE
Fixes small issues, to make it work with Python3 without 2to3 tool.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyo
 .DS_Store
 .tox
+*.egg-info/
+.*.swp

--- a/noseprogressive/__init__.py
+++ b/noseprogressive/__init__.py
@@ -1,1 +1,3 @@
-from plugin import ProgressivePlugin
+from __future__ import absolute_import
+
+from .plugin import ProgressivePlugin

--- a/noseprogressive/result.py
+++ b/noseprogressive/result.py
@@ -110,7 +110,7 @@ class ProgressiveResult(TextTestResult):
         # it and monkeying around with showAll flags to keep it from printing
         # anything.
         is_error_class = False
-        for cls, (storage, label, is_failure) in self.errorClasses.iteritems():
+        for cls, (storage, label, is_failure) in self.errorClasses.items():
             if isclass(error_class) and issubclass(error_class, cls):
                 if is_failure:
                     test.passed = False
@@ -183,7 +183,7 @@ class ProgressiveResult(TextTestResult):
                         len(storage),
                         is_failure)
                         for (storage, label, is_failure) in
-                            self.errorClasses.itervalues() if len(storage)])
+                            self.errorClasses.values() if len(storage)])
         summary = (', '.join(renderResultType(*a) for a in counts) +
                    ' in %.1fs' % (stop - start))
 

--- a/noseprogressive/tracebacks.py
+++ b/noseprogressive/tracebacks.py
@@ -1,6 +1,8 @@
 """Fancy traceback formatting"""
 
 import os
+import sys
+
 from traceback import extract_tb, format_exception_only
 
 from blessings import Terminal
@@ -56,10 +58,13 @@ def format_traceback(extracted_tb,
 
         # Stack frames:
         for i, (file, line, function, text) in enumerate(extracted_tb):
-            # extract_tb() doesn't return Unicode, so we have to guess at the
-            # encoding. We guess utf-8. Use utf-8, everybody.
+            if sys.version_info.major < 3:
+                # extract_tb() doesn't return Unicode in python2, so we have to guess at the
+                # encoding. We guess utf-8. Use utf-8, everybody.
+                text = ((text and text.strip()) or '').decode('utf-8')
+
             yield (format_shortcut(editor, file, line, function) +
-                   ('    %s\n' % ((text and text.strip()) or '').decode('utf-8')))
+                   ('    %s\n' % text))
 
     # Exception:
     if exc_type is SyntaxError:

--- a/noseprogressive/utils.py
+++ b/noseprogressive/utils.py
@@ -95,7 +95,7 @@ def index_of_test_frame(extracted_tb, exception_type, exception_value, test):
     # one match of equal confidence.
     knower = OneTrackMind()
 
-    if isinstance(test_file, basestring):  # Sometimes it's None.
+    if test_file is not None:  # Sometimes it's None.
         test_file_path = realpath(test_file)
 
         # TODO: Perfect. Right now, I'm just comparing by function name within

--- a/noseprogressive/wrapping.py
+++ b/noseprogressive/wrapping.py
@@ -1,7 +1,6 @@
 """Facilities for wrapping stderr and stdout and dealing with the fallout"""
 
 from __future__ import with_statement
-import __builtin__
 import cmd
 import pdb
 import sys


### PR DESCRIPTION
If you install progressive with `pip install -e`, then pip does not run `2to3` afer installation. That way, nose-progressive become useless under Python3.

This pull request fixes some issues for python3 environment.
