### PR TITLE
Fix for Exception switcharoo

### DIFF
--- a/noseprogressive/result.py
+++ b/noseprogressive/result.py
@@ -146,6 +146,8 @@ class ProgressiveResult(TextTestResult):
         """
         self._recordAndPrintHeadline(test, SkipTest, reason)
         # Python 2.7 users get a little bonus: the reason the test was skipped.
+        if isinstance(reason, Exception):
+            reason = reason.message
         if reason and self._options.show_advisories:
             with self.bar.dodging():
                 self.stream.writeln(reason)


### PR DESCRIPTION
Nose converts things that aren't exceptions into exceptions so this
better handles that case.

This fixes the issue for me and the nose-progressive tests continue to pass. It's possible/likely that there are other situations which this fix doesn't help, but I'm pretty sure there aren't any situations where this fix makes things worse.

r?
