### PR TITLE
AttributeError: 'NoneType' object has no attribute 'decode'

### DIFF
--- a/noseprogressive/tracebacks.py
+++ b/noseprogressive/tracebacks.py
@@ -106,6 +106,8 @@ def _decode(string):
     Unicode. We'll see when we add Python 3 to the tox config.
 
     """
+    if string is None:
+        return 'None'
     return string if isinstance(string, unicode) else string.decode('utf-8', 'replace')
 
 


### PR DESCRIPTION
I ran into the following problem:

```
ERROR: test:SimpleTestCase.test_foo
  vi +133 env/lib/python2.6/site-packages/nose/case.py  # run
    self.runTest(result)
  vi +151 env/lib/python2.6/site-packages/nose/case.py  # runTest
    test(result)
  vi +398 env/lib/python2.6/site-packages/unittest2/case.py  # __call__
    return self.run(*args, **kwds)
  vi +362 env/lib/python2.6/site-packages/unittest2/case.py  # run
    result.addError(self, sys.exc_info())
  vi +135 env/lib/python2.6/site-packages/nose/proxy.py  # addError
    self.result.addError(self.test, self._prepareErr(err))
  vi +161 env/src/nose-progressive/noseprogressive/result.py  # addError
    self._printTraceback(test, err)
  vi +90  env/src/nose-progressive/noseprogressive/result.py  # _printTraceback
    self._options.editor)))
  vi +46  env/src/nose-progressive/noseprogressive/tracebacks.py  # format_traceback
    extracted_tb = _unicode_decode_extracted_tb(extracted_tb)
  vi +117 env/src/nose-progressive/noseprogressive/tracebacks.py  # _unicode_decode_extracted_tb
    for file, line, function, text in extracted_tb]
  vi +111 env/src/nose-progressive/noseprogressive/tracebacks.py  # _decode
    return string if isinstance(string, unicode) else string.decode('utf-8', 'replace')
AttributeError: 'NoneType' object has no attribute 'decode'
```

Test case which causes the above:

```
import unittest2
from decorator import decorator

@decorator
def bar(func, *args, **kwargs):
        return func(*args, **kwargs)

@bar
def foo(arg):
        return arg.attribute


class SimpleTestCase(unittest2.TestCase):
        def test_foo(self):
                foo('foo')
                assert 0
```

Finally, here's what the traceback looks like when using this pull-request:

```
ERROR: test:SimpleTestCase.test_foo
  vi +15 test.py  # test_foo
    foo('foo')
  vi +2  <string>  # foo
    None
  vi +6  test.py  # bar
    return func(*args, **kwargs)
  vi +10 test.py  # foo
    return arg.attribute
AttributeError: 'str' object has no attribute 'attribute'
```
