### PR TITLE
UnicodeDecodeError reading README.rst in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import sys
+import codecs
 
 # Prevent spurious errors during `python setup.py test`, a la
 # http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html:
@@ -18,7 +19,7 @@ setup(
     name='nose-progressive',
     version='1.5',
     description='A testrunner with a progress bar and smarter tracebacks',
-    long_description=open('README.rst').read(),
+    long_description=codecs.open('README.rst', encoding='utf8').read(),
     author='Erik Rose',
     author_email='erikrose@grinchcentral.com',
     license='GPL',


### PR DESCRIPTION
Python 3 build fails like this when run in mock (the Fedora build tool):

```
Traceback (most recent call last):
  File "setup.py", line 21, in <module>
    long_description=open('README.rst').read(),
  File "/usr/lib64/python3.2/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 8178: ordinal not in range(128)
```

You can replicate it by running:

```
LC_ALL=POSIX python3 setup.py 
```

The fix is to explicitly read README.rst as UTF-8.
