### PR TITLE
Fix format handling so it works with py3.4

### DIFF
--- a/noseprogressive/tracebacks.py
+++ b/noseprogressive/tracebacks.py
@@ -41,7 +41,7 @@ def format_traceback(extracted_tb,
                         function=None):
         """Return a pretty-printed editor shortcut."""
         return template.format(editor=editor,
-                               line_number=line_number,
+                               line_number=str(line_number),
                                path=path,
                                function=function or u'',
                                hash_if_function=u'  # ' if function else u'',

--- a/noseprogressive/tracebacks.py
+++ b/noseprogressive/tracebacks.py
@@ -41,7 +41,7 @@ def format_traceback(extracted_tb,
                         function=None):
         """Return a pretty-printed editor shortcut."""
         return template.format(editor=editor,
-                               line_number=str(line_number),
+                               line_number=line_number or 0,
                                path=path,
                                function=function or u'',
                                hash_if_function=u'  # ' if function else u'',


### PR DESCRIPTION
Nose-progressive fails while building with python 3.4 in fedora:
http://kojipkgs.fedoraproject.org//work/tasks/5198/6855198/build.log
because of line_number is None when formatting

Python 3.3:

```
>>> line = None
>>> line_max = 10
>>> '+{line_number:<{line_number_max_width}}'.format(line_number=line, line_number_max_width=line_max)
'+None 
```

Python 3.4

```
>>> line = None
>>> line_max = 10
>>> '+{line_number:<{line_number_max_width}}'.format(line_number=line, line_number_max_width=line_max)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: non-empty format string passed to object.__format__
```

See http://bugs.python.org/issue7994
