### PR TITLE
Fix use of deprecated Exception.message in Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .tox
 *.egg-info/
 .*.swp
+build

--- a/noseprogressive/result.py
+++ b/noseprogressive/result.py
@@ -148,7 +148,8 @@ class ProgressiveResult(TextTestResult):
         self._recordAndPrintHeadline(test, SkipTest, reason)
         # Python 2.7 users get a little bonus: the reason the test was skipped.
         if isinstance(reason, Exception):
-            reason = reason.message
+            reason = getattr(reason, 'message', None) or getattr(
+                reason, 'args')[0]
         if reason and self._options.show_advisories:
             with self.bar.dodging():
                 self.stream.writeln(reason)

--- a/noseprogressive/tracebacks.py
+++ b/noseprogressive/tracebacks.py
@@ -41,7 +41,7 @@ def format_traceback(extracted_tb,
                         function=None):
         """Return a pretty-printed editor shortcut."""
         return template.format(editor=editor,
-                               line_number=line_number,
+                               line_number=str(line_number),
                                path=path,
                                function=function or u'',
                                hash_if_function=u'  # ' if function else u'',

--- a/noseprogressive/tracebacks.py
+++ b/noseprogressive/tracebacks.py
@@ -41,7 +41,7 @@ def format_traceback(extracted_tb,
                         function=None):
         """Return a pretty-printed editor shortcut."""
         return template.format(editor=editor,
-                               line_number=str(line_number),
+                               line_number=line_number or 0,
                                path=path,
                                function=function or u'',
                                hash_if_function=u'  # ' if function else u'',


### PR DESCRIPTION
This is a quick attempt to fix issue #72. I've built this on top of pull request #69, as that was also affecting my testing. I haven't added any test coverage because in the limited time available I couldn't get to grips with the unittest/nose internals about how to raise a skip with the decorator that was causing me real-world problems. 
