### PR TITLE
Handle KeyboardInterrupt as nose does.

### DIFF
--- a/noseprogressive/runner.py
+++ b/noseprogressive/runner.py
@@ -39,7 +39,10 @@ class ProgressiveRunner(nose.core.TextTestRunner):
 
         result = self._makeResult()
         startTime = time()
-        test(result)
+        try:
+            test(result)
+        except KeyboardInterrupt:
+            pass
         stopTime = time()
 
         # We don't care to hear about errors again at the end; we take care of

--- a/noseprogressive/runner.py
+++ b/noseprogressive/runner.py
@@ -42,6 +42,11 @@ class ProgressiveRunner(nose.core.TextTestRunner):
         try:
             test(result)
         except KeyboardInterrupt:
+            # we need to ignore these exception to not
+            # show traceback when user intentionally
+            # interrupted test suite execution, and
+            # to output some reasonable results on
+            # already passed and failed tests.
             pass
         stopTime = time()
 


### PR DESCRIPTION
Original TextTestRunner from nose ([the place in nose.core](https://github.com/nose-devs/nose/blob/master/nose/core.py#L63))
handles KeyboardInterrupt gracefully and runs
all necessary methods like result.printSummary and plugins.finalize.

This patch makes nose-progressive behave like original TextTestRunner.