### PR TITLE
Add option to display successful tests

### DIFF
--- a/noseprogressive/plugin.py
+++ b/noseprogressive/plugin.py
@@ -143,6 +143,12 @@ class ProgressivePlugin(Plugin):
                           help='A str.format() template for the non-code lines'
                                ' of the traceback. '
                                '[NOSE_PROGRESSIVE_EDITOR_SHORTCUT_TEMPLATE]')
+        parser.add_option('--progressive-success',
+                          action='store_true',
+                          dest='show_success',
+                          default=env.get('NOSE_PROGRESSIVE_SUCCESS', False),
+                          help='Show successful tests. '
+                               '[NOSE_PROGRESSIVE_SUCCESS]')
 
     def configure(self, options, conf):
         """Turn style-forcing on if bar-forcing is on.

--- a/noseprogressive/result.py
+++ b/noseprogressive/result.py
@@ -166,6 +166,11 @@ class ProgressiveResult(TextTestResult):
         self._printHeadline('FAIL', test)
         self._printTraceback(test, err)
 
+    def addSuccess(self, test):
+        super(ProgressiveResult, self).addSuccess(test)
+        if self._options.show_success:
+            self._printHeadline('OK', test)
+
     def printSummary(self, start, stop):
         """As a final summary, print number of tests, broken down by result."""
         def renderResultType(type, number, is_failure):


### PR DESCRIPTION
Currently nose-progressive only displays failing or error tests.

When I write tests as a developer, I like to see that my newly written tests are there and OK.

This PR adds an option to display successful tests.
Error and failures are still displayed just when they occurred of course!